### PR TITLE
fix: Core Foundation object memory leak

### DIFF
--- a/ios/Classes/SYPictureMetadata/SYMetadata.m
+++ b/ios/Classes/SYPictureMetadata/SYMetadata.m
@@ -77,6 +77,7 @@
     CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(source, 0, (__bridge CFDictionaryRef)options);
     if (properties) {
         dictionary = (__bridge NSDictionary*)properties;
+        CFRelease(properties);
     }
     
     CFRelease(source);
@@ -99,6 +100,7 @@
     CFDictionaryRef properties = CGImageSourceCopyPropertiesAtIndex(source, 0, (__bridge CFDictionaryRef)options);
     if (properties) {
         dictionary = (__bridge NSDictionary*)properties;
+        CFRelease(properties);
     }
     
     CFRelease(source);


### PR DESCRIPTION
解决Core Foundation对象的内存泄漏问题