### PR TITLE
Prevent OOM when getting EXIF rotationdegrees for large image 

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/core/CompressFileHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/core/CompressFileHandler.kt
@@ -80,8 +80,7 @@ class CompressFileHandler(private val call: MethodCall, result: MethodChannel.Re
             val rotate = args[5] as Int
             val autoCorrectionAngle = args[6] as Boolean
             val exifRotate = if (autoCorrectionAngle) {
-                val bytes = File(file).readBytes()
-                Exif.getRotationDegrees(bytes)
+                Exif.getRotationDegrees(File(file))
             } else {
                 0
             }


### PR DESCRIPTION
We're experiencing an Out Of Memory exception on android for large image files when compressing an image by calling compressAndGetFile and autoCorrectionAngle = true. 
It is caused by val bytes = File(file).readBytes(). 
Exif.getRotationDegrees also has a method for files which fixes the OOM. 