### PR TITLE
bump web package to 1.1.0

### DIFF
--- a/packages/flutter_image_compress_web/pubspec.yaml
+++ b/packages/flutter_image_compress_web/pubspec.yaml
@@ -14,7 +14,7 @@ dependencies:
     sdk: flutter
 
   flutter_image_compress_platform_interface: ^1.0.5
-  web: ^0.5.1
+  web: ^1.1.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR bumps the `web` package from version 0.5.1 to 1.1.0