### PR TITLE
Remove outdated note from CompressFormat.webp

### DIFF
--- a/packages/flutter_image_compress_platform_interface/lib/src/compress_format.dart
+++ b/packages/flutter_image_compress_platform_interface/lib/src/compress_format.dart
@@ -1,12 +1,10 @@
 enum CompressFormat {
   jpeg,
   png,
+  webp,
 
   /// - iOS: Supported from iOS11+.
   /// - Android: Supported from API 28+ which require hardware encoder supports,
   ///   Use [HeifWriter](https://developer.android.com/reference/androidx/heifwriter/HeifWriter.html)
   heic,
-
-  /// Only supported on Android.
-  webp,
 }


### PR DESCRIPTION
The doc comment on `CompressFormat.webp` was no longer accurate as WebP is supported on all platforms.