### PR TITLE
fix(Android): decode wide-gamut sources into sRGB

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/ext/BitmapCompressExt.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/ext/BitmapCompressExt.kt
@@ -1,12 +1,26 @@
 package com.fluttercandies.flutter_image_compress.ext
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ColorSpace
 import android.graphics.Matrix
+import android.os.Build
 import com.fluttercandies.flutter_image_compress.ImageCompressPlugin
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import kotlin.math.max
 import kotlin.math.min
+
+/**
+ * Decode wide-gamut sources (Display P3, Adobe RGB) into sRGB so the output
+ * isn't untagged wide-gamut pixels that non-color-managed viewers render
+ * oversaturated. inPreferredColorSpace is API 26+; a no-op on older devices.
+ */
+fun BitmapFactory.Options.preferSrgbColorSpace() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+    }
+}
 
 fun Bitmap.compress(minWidth: Int, minHeight: Int, quality: Int, rotate: Int = 0, format: Int): ByteArray {
     val outputStream = ByteArrayOutputStream()

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
@@ -6,6 +6,7 @@ import android.graphics.BitmapFactory
 import com.fluttercandies.flutter_image_compress.exif.ExifKeeper
 import com.fluttercandies.flutter_image_compress.ext.calcScale
 import com.fluttercandies.flutter_image_compress.ext.compress
+import com.fluttercandies.flutter_image_compress.ext.preferSrgbColorSpace
 import com.fluttercandies.flutter_image_compress.ext.rotate
 import com.fluttercandies.flutter_image_compress.handle.FormatHandler
 import com.fluttercandies.flutter_image_compress.logger.log
@@ -68,6 +69,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
         options.inJustDecodeBounds = false
         options.inPreferredConfig = Bitmap.Config.ARGB_8888
         options.inSampleSize = inSampleSize
+        options.preferSrgbColorSpace()
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
             @Suppress("DEPRECATION")
             options.inDither = true
@@ -122,6 +124,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
             options.inJustDecodeBounds = false
             options.inPreferredConfig = Bitmap.Config.ARGB_8888
             options.inSampleSize = inSampleSize
+            options.preferSrgbColorSpace()
             if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
                 @Suppress("DEPRECATION")
                 options.inDither = true

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.util.Log
 import androidx.heifwriter.HeifWriter
 import com.fluttercandies.flutter_image_compress.ext.calcScale
+import com.fluttercandies.flutter_image_compress.ext.preferSrgbColorSpace
 import com.fluttercandies.flutter_image_compress.ext.rotate
 import com.fluttercandies.flutter_image_compress.handle.FormatHandler
 import com.fluttercandies.flutter_image_compress.logger.log
@@ -76,6 +77,7 @@ class HeifHandler : FormatHandler {
         options.inJustDecodeBounds = false
         options.inPreferredConfig = Bitmap.Config.ARGB_8888
         options.inSampleSize = inSampleSize
+        options.preferSrgbColorSpace()
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             @Suppress("DEPRECATION")
             options.inDither = true


### PR DESCRIPTION
### Problem

On Android, `BitmapFactory` decodes a Display P3 / Adobe RGB source keeping its wide color space, and the subsequent `Bitmap.compress()` does not reliably tag the JPEG/WebP/HEIC output with an ICC profile (it varies by format and API level). A non-color-managed consumer then interprets those wide-gamut pixel values as sRGB, so the result looks oversaturated / hue-shifted compared to the source as shown in the system gallery.

This is most visible with photos from devices that shoot Display P3 by default (widely reported on Samsung). iOS is unaffected because `UIImage+scale.m` already pins its render range to sRGB (`UIGraphicsImageRendererFormat.preferredRange = .standard`); Android had no equivalent.

### Change

Pin every `BitmapFactory` decode in the common Android implementation to sRGB via `BitmapFactory.Options.inPreferredColorSpace`, so wide-gamut sources are color-managed down to sRGB at decode time and the output is self-describing sRGB regardless of the encoder's ICC behaviour. This brings Android in line with the iOS side.

- New `BitmapFactory.Options.preferSrgbColorSpace()` extension (`ext/BitmapCompressExt.kt`)
- Applied at all 3 decode sites: `CommonHandler.compress(byteArray…)`, `CommonHandler.handleFile`, `HeifHandler.makeOption`
- `inPreferredColorSpace` exists from API 26; the helper is a no-op below that, where the platform has no color management anyway. No public API change.

### Verification

The repo has no Android instrumentation-test harness, so this was verified on a physical device (Galaxy S21, Android 15):

1. Built a JPEG carrying an Apple "Display P3" ICC profile (solid saturated color).
2. Ran `FlutterImageCompress.compressWithFile(..., format: jpeg)` and scanned the output bytes for the ICC `Display P3` signature.

| Build | Result |
|-------|--------|
| `main` (before) | output JPEG still carries the **Display P3** profile → wide-gamut pixels passed through |
| this branch | Display P3 profile **gone**, output is sRGB |

(Happy to add an integration test under `packages/flutter_image_compress/example/integration_test/` if you want one — would need a small P3 fixture asset.)

### Open question

Should this be unconditional (matches iOS, "just works" for the common case) or gated behind a new opt-in parameter? I went with unconditional for parity, but can rework it into a `keepColorSpace` / `targetColorSpace` option if you'd prefer to preserve the current passthrough behaviour by default.
