### PR TITLE
fix(Android): decode wide-gamut sources into sRGB

### DIFF
--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/ext/BitmapCompressExt.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/ext/BitmapCompressExt.kt
@@ -1,12 +1,26 @@
 package com.fluttercandies.flutter_image_compress.ext
 
 import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.ColorSpace
 import android.graphics.Matrix
+import android.os.Build
 import com.fluttercandies.flutter_image_compress.ImageCompressPlugin
 import java.io.ByteArrayOutputStream
 import java.io.OutputStream
 import kotlin.math.max
 import kotlin.math.min
+
+/**
+ * Decode wide-gamut sources (Display P3, Adobe RGB) into sRGB so the output
+ * isn't untagged wide-gamut pixels that non-color-managed viewers render
+ * oversaturated. inPreferredColorSpace is API 26+; a no-op on older devices.
+ */
+fun BitmapFactory.Options.preferSrgbColorSpace() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+    }
+}
 
 fun Bitmap.compress(minWidth: Int, minHeight: Int, quality: Int, rotate: Int = 0, format: Int): ByteArray {
     val outputStream = ByteArrayOutputStream()

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/common/CommonHandler.kt
@@ -6,6 +6,7 @@ import android.graphics.BitmapFactory
 import com.fluttercandies.flutter_image_compress.exif.ExifKeeper
 import com.fluttercandies.flutter_image_compress.ext.calcScale
 import com.fluttercandies.flutter_image_compress.ext.compress
+import com.fluttercandies.flutter_image_compress.ext.preferSrgbColorSpace
 import com.fluttercandies.flutter_image_compress.ext.rotate
 import com.fluttercandies.flutter_image_compress.handle.FormatHandler
 import com.fluttercandies.flutter_image_compress.logger.log
@@ -68,6 +69,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
         options.inJustDecodeBounds = false
         options.inPreferredConfig = Bitmap.Config.ARGB_8888
         options.inSampleSize = inSampleSize
+        options.preferSrgbColorSpace()
         if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
             @Suppress("DEPRECATION")
             options.inDither = true
@@ -122,6 +124,7 @@ class CommonHandler(override val type: Int) : FormatHandler {
             options.inJustDecodeBounds = false
             options.inPreferredConfig = Bitmap.Config.ARGB_8888
             options.inSampleSize = inSampleSize
+            options.preferSrgbColorSpace()
             if (android.os.Build.VERSION.SDK_INT < android.os.Build.VERSION_CODES.M) {
                 @Suppress("DEPRECATION")
                 options.inDither = true

--- a/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
+++ b/packages/flutter_image_compress_common/android/src/main/kotlin/com/fluttercandies/flutter_image_compress/handle/heif/HeifHandler.kt
@@ -7,6 +7,7 @@ import android.os.Build
 import android.util.Log
 import androidx.heifwriter.HeifWriter
 import com.fluttercandies.flutter_image_compress.ext.calcScale
+import com.fluttercandies.flutter_image_compress.ext.preferSrgbColorSpace
 import com.fluttercandies.flutter_image_compress.ext.rotate
 import com.fluttercandies.flutter_image_compress.handle.FormatHandler
 import com.fluttercandies.flutter_image_compress.logger.log
@@ -76,6 +77,7 @@ class HeifHandler : FormatHandler {
         options.inJustDecodeBounds = false
         options.inPreferredConfig = Bitmap.Config.ARGB_8888
         options.inSampleSize = inSampleSize
+        options.preferSrgbColorSpace()
         if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
             @Suppress("DEPRECATION")
             options.inDither = true


### PR DESCRIPTION
## Problem

Photos shot in a wide gamut (Display P3, Adobe RGB) come back oversaturated after compression on Android.

`BitmapFactory` keeps the source color space when decoding, so the bitmap holds P3/Adobe RGB pixels. `Bitmap.compress()` does not reliably tag the JPEG/WebP/HEIC output with a matching ICC profile, so the file ends up as *untagged wide-gamut pixels*. Any viewer that doesn't color-manage (most social apps, plain `<img>`, many image views) interprets those numbers as sRGB and renders them noticeably more saturated than the original.

This is easy to hit on Samsung devices, whose camera shoots Display P3 by default.

### Reproduce

1. On a device that captures Display P3 (e.g. a recent Galaxy), take a photo of something saturated (red/green).
2. Run it through `FlutterImageCompress.compressWithFile` / `compressWithList`.
3. Open source and output side by side in a non-color-managed viewer — the output is visibly oversaturated.

## Fix

Pin every `BitmapFactory` decode to sRGB via `BitmapFactory.Options.inPreferredColorSpace`, so the pixels written out actually are sRGB — which is what an untagged file is read as anyway.

Added as a small extension in `BitmapCompressExt.kt` and applied at the three option-building sites:

- `CommonHandler` — byte-array path
- `CommonHandler` — file path
- `HeifHandler.makeOption`

## Notes

- `inPreferredColorSpace` is API 26+; the helper is a no-op below that, so behavior on older devices is unchanged.
- sRGB sources are unaffected — the decode already produces sRGB.
- This brings Android in line with iOS, which already pins its render range to sRGB (`UIImage+scale.m`: `format.preferredRange = UIGraphicsImageRendererFormatRangeStandard`, "keeps output in sRGB … renderer default is automatic, which produces P3/extended-range bitmaps on wide-gamut devices") and strips the source `ProfileName` before re-encoding (`CompressHandler.m`).
- No CHANGELOG edit, per `CONTRIBUTING.md` (generated by `melos version` from the commit log). Commit is `fix(Android): …`.
